### PR TITLE
检查 ZIP 内 AI 模型权重合计不超过 200MB

### DIFF
--- a/components/games/GameUploadForm.tsx
+++ b/components/games/GameUploadForm.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useState } from "react";
-import JSZip, { type JSZipObject } from "jszip";
 import { type Result } from "@/types/common/result";
 import { SGame } from "@/schema/game";
 import {
@@ -12,65 +11,11 @@ import {
 import {
   MAX_MODEL_WEIGHT_TOTAL_BYTES,
   formatMegabytes,
-  isModelWeightFile,
 } from "@/lib/validation/model-weight";
 
 interface GameUploadFormProps {
   action: (formData: FormData) => Promise<Result<{ game: SGame }, UploadGameActionError>>;
   onSuccess: (data: { game: SGame }) => void;
-}
-
-interface WeightPrecheckResult {
-  totalBytes: number;
-  files: { path: string; bytes: number }[];
-  exceeded: boolean;
-}
-
-// JSZip exposes the uncompressed size of each entry through its internal
-// `_data.uncompressedSize` field. This has been stable across major JSZip
-// releases and avoids decompressing every weight file just to measure size.
-interface JSZipObjectWithInternal extends JSZipObject {
-  _data?: { uncompressedSize?: number };
-}
-
-async function measureEntryBytes(entry: JSZipObject): Promise<number> {
-  const internal = entry as JSZipObjectWithInternal;
-  const known = internal._data?.uncompressedSize;
-  if (typeof known === "number" && Number.isFinite(known) && known >= 0) {
-    return known;
-  }
-  const data = await entry.async("uint8array");
-  return data.byteLength;
-}
-
-async function precheckWeightFiles(file: File): Promise<WeightPrecheckResult | { error: string }> {
-  let zip: JSZip;
-  try {
-    zip = await JSZip.loadAsync(file);
-  } catch {
-    return { error: "无法解析 ZIP 文件，请确认文件未损坏" };
-  }
-
-  const weightEntries: JSZipObject[] = [];
-  for (const [, entry] of Object.entries(zip.files)) {
-    if (entry.dir) continue;
-    if (!isModelWeightFile(entry.name)) continue;
-    weightEntries.push(entry);
-  }
-
-  let totalBytes = 0;
-  const files: { path: string; bytes: number }[] = [];
-  for (const entry of weightEntries) {
-    const bytes = await measureEntryBytes(entry);
-    totalBytes += bytes;
-    files.push({ path: entry.name, bytes });
-  }
-
-  return {
-    totalBytes,
-    files,
-    exceeded: totalBytes > MAX_MODEL_WEIGHT_TOTAL_BYTES,
-  };
 }
 
 export function GameUploadForm({ action, onSuccess }: GameUploadFormProps) {
@@ -79,38 +24,14 @@ export function GameUploadForm({ action, onSuccess }: GameUploadFormProps) {
   const [zipFile, setZipFile] = useState<File | null>(null);
   const [error, setError] = useState<UploadGameActionError | null>(null);
   const [isSaving, setIsSaving] = useState(false);
-  const [isPrechecking, setIsPrechecking] = useState(false);
-  const [weightPrecheck, setWeightPrecheck] = useState<WeightPrecheckResult | null>(null);
 
-  const handleFileChange = async (file: File | null) => {
+  const handleFileChange = (file: File | null) => {
     setZipFile(file);
-    setWeightPrecheck(null);
     setError(null);
-
-    if (!file) return;
-
-    setIsPrechecking(true);
-    const result = await precheckWeightFiles(file);
-    setIsPrechecking(false);
-
-    if ("error" in result) {
-      setError(result.error);
-      return;
-    }
-
-    setWeightPrecheck(result);
   };
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-
-    if (weightPrecheck?.exceeded) {
-      setError(
-        `ZIP 中 AI 模型权重文件合计 ${formatMegabytes(weightPrecheck.totalBytes)}，` +
-          `超过上限 ${formatMegabytes(MAX_MODEL_WEIGHT_TOTAL_BYTES)}，请删减权重后重试`,
-      );
-      return;
-    }
 
     setError(null);
     setIsSaving(true);
@@ -136,7 +57,7 @@ export function GameUploadForm({ action, onSuccess }: GameUploadFormProps) {
   const validationError = getHtmlValidationError(error);
   const errorMessage = getErrorMessage(error);
   const weightDetails = getWeightDetails(error);
-  const submitDisabled = isSaving || isPrechecking || (weightPrecheck?.exceeded ?? false);
+  const submitDisabled = isSaving;
 
   return (
     <form onSubmit={handleSubmit} className="space-y-6">
@@ -214,7 +135,7 @@ export function GameUploadForm({ action, onSuccess }: GameUploadFormProps) {
           type="file"
           accept=".zip,application/zip,application/x-zip-compressed"
           onChange={(e) => {
-            void handleFileChange(e.target.files?.[0] || null);
+            handleFileChange(e.target.files?.[0] || null);
           }}
           disabled={isSaving}
           className="block w-full text-sm text-gray-700 border border-dashed border-gray-300 rounded-lg px-4 py-3 bg-white cursor-pointer hover:border-blue-400"
@@ -224,25 +145,6 @@ export function GameUploadForm({ action, onSuccess }: GameUploadFormProps) {
           <p className="mt-2 text-sm text-gray-600">
             Selected: {zipFile.name} ({(zipFile.size / (1024 * 1024)).toFixed(2)} MB)
           </p>
-        )}
-        {isPrechecking && (
-          <p className="mt-2 text-sm text-gray-500">正在检查 ZIP 中的 AI 模型权重文件…</p>
-        )}
-        {weightPrecheck && !isPrechecking && (
-          <div
-            className={`mt-2 text-sm ${
-              weightPrecheck.exceeded ? "text-red-600" : "text-gray-600"
-            }`}
-          >
-            <p>
-              检测到 {weightPrecheck.files.length} 个 AI 模型权重文件，合计{" "}
-              {formatMegabytes(weightPrecheck.totalBytes)}（上限{" "}
-              {formatMegabytes(MAX_MODEL_WEIGHT_TOTAL_BYTES)}）。
-            </p>
-            {weightPrecheck.exceeded && (
-              <p className="mt-1">请删减权重文件后再上传。</p>
-            )}
-          </div>
         )}
         <p className="mt-1 text-xs text-gray-500">
           The ZIP must contain an index.html at the root level. HTML files cannot contain inline JavaScript.
@@ -257,7 +159,7 @@ export function GameUploadForm({ action, onSuccess }: GameUploadFormProps) {
           disabled={submitDisabled}
           className="px-6 py-2 bg-blue-600 text-white font-medium rounded-lg hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 disabled:opacity-50 disabled:cursor-not-allowed"
         >
-          {isSaving ? "Uploading..." : isPrechecking ? "Checking..." : "Upload Game"}
+          {isSaving ? "Uploading..." : "Upload Game"}
         </button>
         <button
           type="button"

--- a/components/games/GameUploadForm.tsx
+++ b/components/games/GameUploadForm.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import JSZip, { type JSZipObject } from "jszip";
 import { type Result } from "@/types/common/result";
 import { SGame } from "@/schema/game";
 import {
@@ -8,10 +9,68 @@ import {
   type HtmlZipValidationError,
   type UploadGameActionError,
 } from "@/lib/validation/game-zip";
+import {
+  MAX_MODEL_WEIGHT_TOTAL_BYTES,
+  formatMegabytes,
+  isModelWeightFile,
+} from "@/lib/validation/model-weight";
 
 interface GameUploadFormProps {
   action: (formData: FormData) => Promise<Result<{ game: SGame }, UploadGameActionError>>;
   onSuccess: (data: { game: SGame }) => void;
+}
+
+interface WeightPrecheckResult {
+  totalBytes: number;
+  files: { path: string; bytes: number }[];
+  exceeded: boolean;
+}
+
+// JSZip exposes the uncompressed size of each entry through its internal
+// `_data.uncompressedSize` field. This has been stable across major JSZip
+// releases and avoids decompressing every weight file just to measure size.
+interface JSZipObjectWithInternal extends JSZipObject {
+  _data?: { uncompressedSize?: number };
+}
+
+async function measureEntryBytes(entry: JSZipObject): Promise<number> {
+  const internal = entry as JSZipObjectWithInternal;
+  const known = internal._data?.uncompressedSize;
+  if (typeof known === "number" && Number.isFinite(known) && known >= 0) {
+    return known;
+  }
+  const data = await entry.async("uint8array");
+  return data.byteLength;
+}
+
+async function precheckWeightFiles(file: File): Promise<WeightPrecheckResult | { error: string }> {
+  let zip: JSZip;
+  try {
+    zip = await JSZip.loadAsync(file);
+  } catch {
+    return { error: "无法解析 ZIP 文件，请确认文件未损坏" };
+  }
+
+  const weightEntries: JSZipObject[] = [];
+  for (const [, entry] of Object.entries(zip.files)) {
+    if (entry.dir) continue;
+    if (!isModelWeightFile(entry.name)) continue;
+    weightEntries.push(entry);
+  }
+
+  let totalBytes = 0;
+  const files: { path: string; bytes: number }[] = [];
+  for (const entry of weightEntries) {
+    const bytes = await measureEntryBytes(entry);
+    totalBytes += bytes;
+    files.push({ path: entry.name, bytes });
+  }
+
+  return {
+    totalBytes,
+    files,
+    exceeded: totalBytes > MAX_MODEL_WEIGHT_TOTAL_BYTES,
+  };
 }
 
 export function GameUploadForm({ action, onSuccess }: GameUploadFormProps) {
@@ -20,9 +79,39 @@ export function GameUploadForm({ action, onSuccess }: GameUploadFormProps) {
   const [zipFile, setZipFile] = useState<File | null>(null);
   const [error, setError] = useState<UploadGameActionError | null>(null);
   const [isSaving, setIsSaving] = useState(false);
+  const [isPrechecking, setIsPrechecking] = useState(false);
+  const [weightPrecheck, setWeightPrecheck] = useState<WeightPrecheckResult | null>(null);
+
+  const handleFileChange = async (file: File | null) => {
+    setZipFile(file);
+    setWeightPrecheck(null);
+    setError(null);
+
+    if (!file) return;
+
+    setIsPrechecking(true);
+    const result = await precheckWeightFiles(file);
+    setIsPrechecking(false);
+
+    if ("error" in result) {
+      setError(result.error);
+      return;
+    }
+
+    setWeightPrecheck(result);
+  };
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
+
+    if (weightPrecheck?.exceeded) {
+      setError(
+        `ZIP 中 AI 模型权重文件合计 ${formatMegabytes(weightPrecheck.totalBytes)}，` +
+          `超过上限 ${formatMegabytes(MAX_MODEL_WEIGHT_TOTAL_BYTES)}，请删减权重后重试`,
+      );
+      return;
+    }
+
     setError(null);
     setIsSaving(true);
 
@@ -46,6 +135,8 @@ export function GameUploadForm({ action, onSuccess }: GameUploadFormProps) {
 
   const validationError = getHtmlValidationError(error);
   const errorMessage = getErrorMessage(error);
+  const weightDetails = getWeightDetails(error);
+  const submitDisabled = isSaving || isPrechecking || (weightPrecheck?.exceeded ?? false);
 
   return (
     <form onSubmit={handleSubmit} className="space-y-6">
@@ -57,6 +148,15 @@ export function GameUploadForm({ action, onSuccess }: GameUploadFormProps) {
               {validationError.violations.map((violation, index) => (
                 <li key={`${violation.file}-${violation.type}-${index}`}>
                   {violation.message || `${violation.file}: ${violation.type}`}
+                </li>
+              ))}
+            </ul>
+          )}
+          {weightDetails && weightDetails.files.length > 0 && (
+            <ul className="mt-3 list-disc pl-5 text-sm">
+              {weightDetails.files.map((f) => (
+                <li key={f.path}>
+                  {f.path} — {formatMegabytes(f.bytes)}
                 </li>
               ))}
             </ul>
@@ -114,7 +214,7 @@ export function GameUploadForm({ action, onSuccess }: GameUploadFormProps) {
           type="file"
           accept=".zip,application/zip,application/x-zip-compressed"
           onChange={(e) => {
-            setZipFile(e.target.files?.[0] || null);
+            void handleFileChange(e.target.files?.[0] || null);
           }}
           disabled={isSaving}
           className="block w-full text-sm text-gray-700 border border-dashed border-gray-300 rounded-lg px-4 py-3 bg-white cursor-pointer hover:border-blue-400"
@@ -125,18 +225,39 @@ export function GameUploadForm({ action, onSuccess }: GameUploadFormProps) {
             Selected: {zipFile.name} ({(zipFile.size / (1024 * 1024)).toFixed(2)} MB)
           </p>
         )}
+        {isPrechecking && (
+          <p className="mt-2 text-sm text-gray-500">正在检查 ZIP 中的 AI 模型权重文件…</p>
+        )}
+        {weightPrecheck && !isPrechecking && (
+          <div
+            className={`mt-2 text-sm ${
+              weightPrecheck.exceeded ? "text-red-600" : "text-gray-600"
+            }`}
+          >
+            <p>
+              检测到 {weightPrecheck.files.length} 个 AI 模型权重文件，合计{" "}
+              {formatMegabytes(weightPrecheck.totalBytes)}（上限{" "}
+              {formatMegabytes(MAX_MODEL_WEIGHT_TOTAL_BYTES)}）。
+            </p>
+            {weightPrecheck.exceeded && (
+              <p className="mt-1">请删减权重文件后再上传。</p>
+            )}
+          </div>
+        )}
         <p className="mt-1 text-xs text-gray-500">
           The ZIP must contain an index.html at the root level. HTML files cannot contain inline JavaScript.
+          AI model weight files (.pth/.safetensors/.pt/.ckpt/.onnx/.gguf 等) combined size must be ≤{" "}
+          {formatMegabytes(MAX_MODEL_WEIGHT_TOTAL_BYTES)}.
         </p>
       </div>
 
       <div className="flex gap-4">
         <button
           type="submit"
-          disabled={isSaving}
+          disabled={submitDisabled}
           className="px-6 py-2 bg-blue-600 text-white font-medium rounded-lg hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 disabled:opacity-50 disabled:cursor-not-allowed"
         >
-          {isSaving ? "Uploading..." : "Upload Game"}
+          {isSaving ? "Uploading..." : isPrechecking ? "Checking..." : "Upload Game"}
         </button>
         <button
           type="button"
@@ -170,4 +291,14 @@ function getHtmlValidationError(
   }
 
   return error.code === "html_validation_failed" ? error : null;
+}
+
+function getWeightDetails(
+  error: UploadGameActionError | null,
+): { files: { path: string; bytes: number }[] } | null {
+  if (!error || typeof error === "string" || !("code" in error)) {
+    return null;
+  }
+  if (error.code !== "model_weight_total_too_large") return null;
+  return error.modelWeightDetails ?? null;
 }

--- a/lib/validation/game-zip.test.ts
+++ b/lib/validation/game-zip.test.ts
@@ -1,0 +1,174 @@
+import { describe, expect, test } from "bun:test";
+import JSZip from "jszip";
+import {
+  checkModelWeightTotalSize,
+  createModelWeightTotalTooLargeError,
+  hasGameZipAnalysisError,
+  inspectGameZip,
+  MAX_MODEL_WEIGHT_TOTAL_BYTES,
+} from "./game-zip";
+
+async function buildZip(files: Record<string, Buffer | string>): Promise<Buffer> {
+  const zip = new JSZip();
+  for (const [path, content] of Object.entries(files)) {
+    zip.file(path, content);
+  }
+  return Buffer.from(await zip.generateAsync({ type: "uint8array" }));
+}
+
+function fakeWeightBuffer(bytes: number): Buffer {
+  // Incompressible random bytes so the ZIP does not silently deflate them to
+  // nothing; we want realistic uncompressed size behavior in tests.
+  const buf = Buffer.allocUnsafe(bytes);
+  for (let i = 0; i < bytes; i++) buf[i] = Math.floor(Math.random() * 256);
+  return buf;
+}
+
+describe("checkModelWeightTotalSize", () => {
+  test("returns null when no weight files are present", () => {
+    const result = checkModelWeightTotalSize([
+      { path: "index.html", data: Buffer.from("<html></html>") },
+      { path: "assets/logo.png", data: Buffer.alloc(1024) },
+    ]);
+    expect(result).toBeNull();
+  });
+
+  test("returns null when the cumulative size is under the limit", () => {
+    const result = checkModelWeightTotalSize([
+      { path: "a.pth", data: Buffer.alloc(50 * 1024 * 1024) },
+      { path: "b.safetensors", data: Buffer.alloc(50 * 1024 * 1024) },
+    ]);
+    expect(result).toBeNull();
+  });
+
+  test("returns details when the cumulative size exceeds the limit", () => {
+    const result = checkModelWeightTotalSize([
+      { path: "a.pth", data: Buffer.alloc(120 * 1024 * 1024) },
+      { path: "b.safetensors", data: Buffer.alloc(120 * 1024 * 1024) },
+    ]);
+    expect(result).not.toBeNull();
+    expect(result!.totalBytes).toBe(240 * 1024 * 1024);
+    expect(result!.limitBytes).toBe(MAX_MODEL_WEIGHT_TOTAL_BYTES);
+    expect(result!.files.map((f) => f.path).sort()).toEqual([
+      "a.pth",
+      "b.safetensors",
+    ]);
+  });
+
+  test("respects a custom limit parameter", () => {
+    const result = checkModelWeightTotalSize(
+      [{ path: "a.pth", data: Buffer.alloc(10 * 1024 * 1024) }],
+      1 * 1024 * 1024,
+    );
+    expect(result).not.toBeNull();
+    expect(result!.totalBytes).toBe(10 * 1024 * 1024);
+    expect(result!.limitBytes).toBe(1 * 1024 * 1024);
+  });
+
+  test("ignores non-weight files in the total", () => {
+    const result = checkModelWeightTotalSize(
+      [
+        { path: "a.pth", data: Buffer.alloc(512) },
+        { path: "huge-asset.bin.txt", data: Buffer.alloc(10 * 1024 * 1024) },
+        { path: "b.html", data: Buffer.alloc(10 * 1024 * 1024) },
+      ],
+      1024,
+    );
+    expect(result).toBeNull();
+  });
+});
+
+describe("createModelWeightTotalTooLargeError", () => {
+  test("produces a structured error with the expected shape", () => {
+    const err = createModelWeightTotalTooLargeError({
+      totalBytes: 250 * 1024 * 1024,
+      limitBytes: MAX_MODEL_WEIGHT_TOTAL_BYTES,
+      files: [{ path: "a.pth", bytes: 250 * 1024 * 1024 }],
+    });
+    expect(err.passed).toBe(false);
+    expect(err.error.code).toBe("model_weight_total_too_large");
+    expect(err.error.modelWeightDetails?.totalBytes).toBe(250 * 1024 * 1024);
+    expect(err.error.message).toContain("200.00MB");
+    expect(err.error.message).toContain("250.00MB");
+  });
+});
+
+describe("inspectGameZip with model weight files", () => {
+  test("accepts zips whose weight files are under the 200 MB cap", async () => {
+    const zipBytes = await buildZip({
+      "index.html": "<!doctype html><html><body></body></html>",
+      "weights/model.safetensors": fakeWeightBuffer(2 * 1024 * 1024),
+      "weights/extra.pth": fakeWeightBuffer(1 * 1024 * 1024),
+    });
+
+    const result = await inspectGameZip(zipBytes, { requireRootIndexHtml: true });
+    expect(hasGameZipAnalysisError(result)).toBe(false);
+    expect(result.passed).toBe(true);
+  });
+
+  test("rejects zips whose combined weight size exceeds the limit", async () => {
+    const over = MAX_MODEL_WEIGHT_TOTAL_BYTES + 8 * 1024 * 1024;
+    const zipBytes = await buildZip({
+      "index.html": "<!doctype html><html><body></body></html>",
+      "weights/big.safetensors": fakeWeightBuffer(over),
+    });
+
+    const result = await inspectGameZip(zipBytes, { requireRootIndexHtml: true });
+    expect(hasGameZipAnalysisError(result)).toBe(true);
+    if (!hasGameZipAnalysisError(result)) return;
+
+    expect(result.error.code).toBe("model_weight_total_too_large");
+    expect(result.error.modelWeightDetails).toBeDefined();
+    expect(result.error.modelWeightDetails!.totalBytes).toBeGreaterThanOrEqual(over);
+    expect(result.error.modelWeightDetails!.limitBytes).toBe(MAX_MODEL_WEIGHT_TOTAL_BYTES);
+    expect(
+      result.error.modelWeightDetails!.files.some((f) =>
+        f.path.endsWith("big.safetensors"),
+      ),
+    ).toBe(true);
+  });
+
+  test("runs the weight check before the HTML JS scan so oversized weights short-circuit", async () => {
+    const over = MAX_MODEL_WEIGHT_TOTAL_BYTES + 1 * 1024 * 1024;
+    const zipBytes = await buildZip({
+      // HTML with an inline <script> would normally fail html_validation,
+      // but we expect model_weight_total_too_large to fire first.
+      "index.html": "<!doctype html><html><body><script>alert(1)</script></body></html>",
+      "weights/over.pth": fakeWeightBuffer(over),
+    });
+
+    const result = await inspectGameZip(zipBytes, { requireRootIndexHtml: true });
+    expect(hasGameZipAnalysisError(result)).toBe(true);
+    if (!hasGameZipAnalysisError(result)) return;
+    expect(result.error.code).toBe("model_weight_total_too_large");
+  });
+
+  test("sums sizes across multiple weight files to apply the cap", async () => {
+    const half = MAX_MODEL_WEIGHT_TOTAL_BYTES / 2 + 4 * 1024 * 1024;
+    const zipBytes = await buildZip({
+      "index.html": "<!doctype html><html><body></body></html>",
+      "weights/a.safetensors": fakeWeightBuffer(half),
+      "weights/b.pth": fakeWeightBuffer(half),
+    });
+
+    const result = await inspectGameZip(zipBytes, { requireRootIndexHtml: true });
+    expect(hasGameZipAnalysisError(result)).toBe(true);
+    if (!hasGameZipAnalysisError(result)) return;
+    expect(result.error.code).toBe("model_weight_total_too_large");
+    expect(result.error.modelWeightDetails!.files).toHaveLength(2);
+  });
+
+  test("treats non-weight extensions as out of scope even if they are large", async () => {
+    // A 210 MB asset that is not a weight file should not trip the check.
+    const zipBytes = await buildZip({
+      "index.html": "<!doctype html><html><body></body></html>",
+      "assets/huge-texture.png": fakeWeightBuffer(
+        MAX_MODEL_WEIGHT_TOTAL_BYTES + 8 * 1024 * 1024,
+      ),
+    });
+
+    const result = await inspectGameZip(zipBytes, { requireRootIndexHtml: true });
+    expect(hasGameZipAnalysisError(result)).toBe(false);
+    expect(result.passed).toBe(true);
+  });
+});

--- a/lib/validation/game-zip.ts
+++ b/lib/validation/game-zip.ts
@@ -1,6 +1,17 @@
 import JSZip, { type JSZipObject } from "jszip";
 import { parse } from "parse5";
 import type { DefaultTreeAdapterMap } from "parse5";
+import {
+  MAX_MODEL_WEIGHT_TOTAL_BYTES,
+  formatMegabytes,
+  isModelWeightFile,
+} from "@/lib/validation/model-weight";
+
+export {
+  MAX_MODEL_WEIGHT_TOTAL_BYTES,
+  MODEL_WEIGHT_EXTENSIONS,
+  isModelWeightFile,
+} from "@/lib/validation/model-weight";
 
 type Element = DefaultTreeAdapterMap["element"];
 
@@ -74,12 +85,20 @@ export type GameZipAnalysisErrorCode =
   | "resource_limit_exceeded"
   | "analysis_timeout"
   | "missing_index_html"
-  | "invalid_html_file";
+  | "invalid_html_file"
+  | "model_weight_total_too_large";
+
+export interface ModelWeightOversizeDetails {
+  totalBytes: number;
+  limitBytes: number;
+  files: { path: string; bytes: number }[];
+}
 
 export interface GameZipAnalysisError {
   code: GameZipAnalysisErrorCode;
   message: string;
   file?: string;
+  modelWeightDetails?: ModelWeightOversizeDetails;
 }
 
 export type HtmlZipValidationError = HtmlZipAnalysisViolationResult & {
@@ -121,6 +140,7 @@ function createAnalysisError(
   code: GameZipAnalysisErrorCode,
   message: string,
   file?: string,
+  extra?: Pick<GameZipAnalysisError, "modelWeightDetails">,
 ): HtmlZipAnalysisErrorResult {
   return {
     passed: false,
@@ -129,8 +149,18 @@ function createAnalysisError(
       code,
       message,
       file,
+      ...extra,
     },
   };
+}
+
+export function createModelWeightTotalTooLargeError(
+  details: ModelWeightOversizeDetails,
+): HtmlZipAnalysisErrorResult {
+  const message = `ZIP 中 AI 模型权重文件合计 ${formatMegabytes(details.totalBytes)}，超过上限 ${formatMegabytes(details.limitBytes)}`;
+  return createAnalysisError("model_weight_total_too_large", message, undefined, {
+    modelWeightDetails: details,
+  });
 }
 
 export function createHtmlZipValidationError(
@@ -246,6 +276,11 @@ export async function inspectGameZip(
       "missing_index_html",
       "ZIP 根目录必须包含 index.html 或 index.htm",
     );
+  }
+
+  const weightCheck = checkModelWeightTotalSize(entries);
+  if (weightCheck) {
+    return createModelWeightTotalTooLargeError(weightCheck);
   }
 
   const violations: GameZipViolation[] = [];
@@ -437,6 +472,26 @@ function unwrapSingleTopLevelDirectory(entries: GameZipEntry[]): void {
 
 export function hasRootIndexHtml(entries: Pick<GameZipEntry, "path">[]): boolean {
   return entries.some((entry) => /^index\.html?$/i.test(entry.path));
+}
+
+// Returns details when the cumulative size of AI model weight files inside
+// the ZIP exceeds MAX_MODEL_WEIGHT_TOTAL_BYTES; otherwise returns null.
+export function checkModelWeightTotalSize(
+  entries: { path: string; data: Buffer | Uint8Array }[],
+  limitBytes: number = MAX_MODEL_WEIGHT_TOTAL_BYTES,
+): ModelWeightOversizeDetails | null {
+  let totalBytes = 0;
+  const files: { path: string; bytes: number }[] = [];
+
+  for (const entry of entries) {
+    if (!isModelWeightFile(entry.path)) continue;
+    const bytes = entry.data.byteLength;
+    totalBytes += bytes;
+    files.push({ path: entry.path, bytes });
+  }
+
+  if (totalBytes <= limitBytes) return null;
+  return { totalBytes, limitBytes, files };
 }
 
 function normalizeZipEntryPath(

--- a/lib/validation/model-weight.test.ts
+++ b/lib/validation/model-weight.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, test } from "bun:test";
+import {
+  MAX_MODEL_WEIGHT_TOTAL_BYTES,
+  MODEL_WEIGHT_EXTENSIONS,
+  formatMegabytes,
+  isModelWeightFile,
+} from "./model-weight";
+
+describe("isModelWeightFile", () => {
+  test("matches every declared extension case-insensitively", () => {
+    for (const ext of MODEL_WEIGHT_EXTENSIONS) {
+      expect(isModelWeightFile(`weights${ext}`)).toBe(true);
+      expect(isModelWeightFile(`WEIGHTS${ext.toUpperCase()}`)).toBe(true);
+      expect(isModelWeightFile(`nested/dir/model${ext}`)).toBe(true);
+    }
+  });
+
+  test("does not match non-weight files", () => {
+    expect(isModelWeightFile("index.html")).toBe(false);
+    expect(isModelWeightFile("game/assets/logo.png")).toBe(false);
+    expect(isModelWeightFile("readme.md")).toBe(false);
+    expect(isModelWeightFile("scripts/main.js")).toBe(false);
+  });
+
+  test("requires the suffix at the very end of the path", () => {
+    expect(isModelWeightFile("model.pth.txt")).toBe(false);
+    expect(isModelWeightFile("archive.safetensors.bak")).toBe(false);
+  });
+
+  test("handles extensions appearing inside directory names", () => {
+    expect(isModelWeightFile(".pth/index.html")).toBe(false);
+    expect(isModelWeightFile("safetensors/readme.md")).toBe(false);
+  });
+});
+
+describe("MAX_MODEL_WEIGHT_TOTAL_BYTES", () => {
+  test("equals 200 MB expressed in binary megabytes", () => {
+    expect(MAX_MODEL_WEIGHT_TOTAL_BYTES).toBe(200 * 1024 * 1024);
+  });
+});
+
+describe("formatMegabytes", () => {
+  test("rounds to 2 decimal places with MB suffix", () => {
+    expect(formatMegabytes(0)).toBe("0.00MB");
+    expect(formatMegabytes(1024 * 1024)).toBe("1.00MB");
+    expect(formatMegabytes(1.5 * 1024 * 1024)).toBe("1.50MB");
+    expect(formatMegabytes(MAX_MODEL_WEIGHT_TOTAL_BYTES)).toBe("200.00MB");
+  });
+});

--- a/lib/validation/model-weight.ts
+++ b/lib/validation/model-weight.ts
@@ -1,0 +1,32 @@
+// Client-safe constants and helpers for AI model weight validation.
+// Kept separate from lib/validation/game-zip.ts so the browser bundle does
+// not pull in parse5 / the Node-only ZIP inspection pipeline.
+
+export const MODEL_WEIGHT_EXTENSIONS: readonly string[] = [
+  ".pth",
+  ".pt",
+  ".safetensors",
+  ".ckpt",
+  ".bin",
+  ".onnx",
+  ".gguf",
+  ".ggml",
+  ".h5",
+  ".hdf5",
+  ".pb",
+  ".tflite",
+  ".msgpack",
+  ".npz",
+  ".pkl",
+];
+
+export const MAX_MODEL_WEIGHT_TOTAL_BYTES = 200 * 1024 * 1024;
+
+export function isModelWeightFile(path: string): boolean {
+  const lower = path.toLowerCase();
+  return MODEL_WEIGHT_EXTENSIONS.some((ext) => lower.endsWith(ext));
+}
+
+export function formatMegabytes(bytes: number): string {
+  return `${(bytes / (1024 * 1024)).toFixed(2)}MB`;
+}

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "eslint",
+    "test": "bun test",
     "seed": "bun run scripts/seed.ts"
   },
   "dependencies": {


### PR DESCRIPTION
## 摘要

在游戏 ZIP 上传中校验常见 AI 权重后缀文件解压后合计 ≤ 200MB；服务端 `inspectGameZip` 强制执行，前端选 ZIP 后预检。

## 测试

`bun test lib/validation/`

---

Closes #45