### PR TITLE
feat: 增加上传 ZIP 后的 JS 压缩字符统计

### DIFF
--- a/app/actions/game.ts
+++ b/app/actions/game.ts
@@ -4,7 +4,7 @@ import { createGame, findGameById, deleteGameById } from "@/lib/db/game";
 import { uploadGameFiles, deleteGameFiles } from "@/lib/cos";
 import { requireAuthenticatedUser } from "@/lib/auth/session";
 import { Result } from "@/types/common/result";
-import { SGame } from "@/schema/game";
+import { type UploadGameActionSuccessData } from "@/types/game-upload";
 import {
   createHtmlZipValidationError,
   hasGameZipAnalysisError,
@@ -51,7 +51,7 @@ function getContentType(filePath: string): string {
 
 export async function uploadGameAction(
   formData: FormData,
-): Promise<Result<{ game: SGame }, UploadGameActionError>> {
+): Promise<Result<UploadGameActionSuccessData, UploadGameActionError>> {
   const currentUser = await requireAuthenticatedUser().catch(() => null);
 
   if (!currentUser) {
@@ -99,7 +99,7 @@ export async function uploadGameAction(
     };
   }
 
-  const { entries } = inspectionResult;
+  const { entries, jsAnalysis } = inspectionResult;
 
   // Save game metadata to database first
   const newGame = await createGame({
@@ -130,7 +130,10 @@ export async function uploadGameAction(
 
   return {
     success: true,
-    data: { game: newGame },
+    data: {
+      game: newGame,
+      jsAnalysis,
+    },
   };
 }
 

--- a/app/upload-game/page.tsx
+++ b/app/upload-game/page.tsx
@@ -1,16 +1,9 @@
 "use client";
 
-import { useRouter } from "next/navigation";
 import { uploadGameAction } from "@/app/actions/game";
 import { GameUploadForm } from "@/components/games/GameUploadForm";
 
 export default function UploadGamePage() {
-  const router = useRouter();
-
-  const handleSuccess = (data: { game: { _id: string } }) => {
-    router.push(`/games/${data.game._id}`);
-  };
-
   return (
     <div className="max-w-4xl mx-auto p-6">
       <div className="mb-8">
@@ -21,7 +14,7 @@ export default function UploadGamePage() {
           Upload a ZIP file containing your HTML game
         </p>
       </div>
-      <GameUploadForm action={uploadGameAction} onSuccess={handleSuccess} />
+      <GameUploadForm action={uploadGameAction} />
     </div>
   );
 }

--- a/bun.lock
+++ b/bun.lock
@@ -39,6 +39,7 @@
         "server-only": "^0.0.1",
         "sonner": "^2.0.7",
         "tailwind-merge": "^3.4.0",
+        "terser": "5.46.1",
         "tiptap-markdown": "^0.9.0",
         "valibot": "^1.1.0",
       },
@@ -192,6 +193,8 @@
     "@jridgewell/remapping": ["@jridgewell/remapping@2.3.5", "", { "dependencies": { "@jridgewell/gen-mapping": "^0.3.5", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ=="],
 
     "@jridgewell/resolve-uri": ["@jridgewell/resolve-uri@3.1.2", "", {}, "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw=="],
+
+    "@jridgewell/source-map": ["@jridgewell/source-map@0.3.11", "", { "dependencies": { "@jridgewell/gen-mapping": "^0.3.5", "@jridgewell/trace-mapping": "^0.3.25" } }, "sha512-ZMp1V8ZFcPG5dIWnQLr3NSI1MiCU7UETdS/A0G8V/XWHvJv3ZsFqutJn1Y5RPmAPX6F3BiE397OqveU/9NCuIA=="],
 
     "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
 
@@ -565,6 +568,8 @@
 
     "bson": ["bson@7.2.0", "", {}, "sha512-YCEo7KjMlbNlyHhz7zAZNDpIpQbd+wOEHJYezv0nMYTn4x31eIUM2yomNNubclAt63dObUzKHWsBLJ9QcZNSnQ=="],
 
+    "buffer-from": ["buffer-from@1.1.2", "", {}, "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="],
+
     "call-bind": ["call-bind@1.0.8", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.0", "es-define-property": "^1.0.0", "get-intrinsic": "^1.2.4", "set-function-length": "^1.2.2" } }, "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww=="],
 
     "call-bind-apply-helpers": ["call-bind-apply-helpers@1.0.2", "", { "dependencies": { "es-errors": "^1.3.0", "function-bind": "^1.1.2" } }, "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ=="],
@@ -602,6 +607,8 @@
     "combined-stream": ["combined-stream@1.0.8", "", { "dependencies": { "delayed-stream": "~1.0.0" } }, "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg=="],
 
     "comma-separated-tokens": ["comma-separated-tokens@2.0.3", "", {}, "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg=="],
+
+    "commander": ["commander@2.20.3", "", {}, "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="],
 
     "concat-map": ["concat-map@0.0.1", "", {}, "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="],
 
@@ -1383,7 +1390,11 @@
 
     "sonner": ["sonner@2.0.7", "", { "peerDependencies": { "react": "^18.0.0 || ^19.0.0 || ^19.0.0-rc", "react-dom": "^18.0.0 || ^19.0.0 || ^19.0.0-rc" } }, "sha512-W6ZN4p58k8aDKA4XPcx2hpIQXBRAgyiWVkYhT7CvK6D3iAu7xjvVyhQHg2/iaKJZ1XVJ4r7XuwGL+WGEK37i9w=="],
 
+    "source-map": ["source-map@0.6.1", "", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
+
     "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
+
+    "source-map-support": ["source-map-support@0.5.21", "", { "dependencies": { "buffer-from": "^1.0.0", "source-map": "^0.6.0" } }, "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w=="],
 
     "space-separated-tokens": ["space-separated-tokens@2.0.2", "", {}, "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q=="],
 
@@ -1438,6 +1449,8 @@
     "tailwindcss": ["tailwindcss@4.1.18", "", {}, "sha512-4+Z+0yiYyEtUVCScyfHCxOYP06L5Ne+JiHhY2IjR2KWMIWhJOYZKLSGZaP5HkZ8+bY0cxfzwDE5uOmzFXyIwxw=="],
 
     "tapable": ["tapable@2.3.0", "", {}, "sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg=="],
+
+    "terser": ["terser@5.46.1", "", { "dependencies": { "@jridgewell/source-map": "^0.3.3", "acorn": "^8.15.0", "commander": "^2.20.0", "source-map-support": "~0.5.20" }, "bin": { "terser": "bin/terser" } }, "sha512-vzCjQO/rgUuK9sf8VJZvjqiqiHFaZLnOiimmUuOKODxWL8mm/xua7viT7aqX7dgPY60otQjUotzFMmCB4VdmqQ=="],
 
     "tinyglobby": ["tinyglobby@0.2.15", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.3" } }, "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ=="],
 

--- a/components/games/GameUploadForm.tsx
+++ b/components/games/GameUploadForm.tsx
@@ -1,8 +1,9 @@
 "use client";
 
+import Link from "next/link";
 import { useState } from "react";
 import { type Result } from "@/types/common/result";
-import { SGame } from "@/schema/game";
+import { type UploadGameActionSuccessData } from "@/types/game-upload";
 import {
   isStructuredUploadGameError,
   type HtmlZipValidationError,
@@ -10,16 +11,20 @@ import {
 } from "@/lib/validation/game-zip";
 
 interface GameUploadFormProps {
-  action: (formData: FormData) => Promise<Result<{ game: SGame }, UploadGameActionError>>;
-  onSuccess: (data: { game: SGame }) => void;
+  action: (
+    formData: FormData,
+  ) => Promise<Result<UploadGameActionSuccessData, UploadGameActionError>>;
 }
 
-export function GameUploadForm({ action, onSuccess }: GameUploadFormProps) {
+export function GameUploadForm({ action }: GameUploadFormProps) {
   const [title, setTitle] = useState("");
   const [description, setDescription] = useState("");
   const [zipFile, setZipFile] = useState<File | null>(null);
   const [error, setError] = useState<UploadGameActionError | null>(null);
   const [isSaving, setIsSaving] = useState(false);
+  const [successData, setSuccessData] = useState<UploadGameActionSuccessData | null>(
+    null,
+  );
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -41,11 +46,28 @@ export function GameUploadForm({ action, onSuccess }: GameUploadFormProps) {
       return;
     }
 
-    onSuccess(result.data);
+    setSuccessData(result.data);
+    setIsSaving(false);
   };
 
   const validationError = getHtmlValidationError(error);
   const errorMessage = getErrorMessage(error);
+
+  if (successData) {
+    return (
+      <UploadSummary
+        data={successData}
+        onUploadAnother={() => {
+          setSuccessData(null);
+          setTitle("");
+          setDescription("");
+          setZipFile(null);
+          setError(null);
+          setIsSaving(false);
+        }}
+      />
+    );
+  }
 
   return (
     <form onSubmit={handleSubmit} className="space-y-6">
@@ -148,6 +170,110 @@ export function GameUploadForm({ action, onSuccess }: GameUploadFormProps) {
       </div>
     </form>
   );
+}
+
+interface UploadSummaryProps {
+  data: UploadGameActionSuccessData;
+  onUploadAnother: () => void;
+}
+
+function UploadSummary({ data, onUploadAnother }: UploadSummaryProps) {
+  const { game, jsAnalysis } = data;
+  const isOverLimit = jsAnalysis.excessChars > 0;
+
+  return (
+    <div className="space-y-6">
+      <div className="rounded-xl border border-green-200 bg-green-50 p-6">
+        <h2 className="text-xl font-semibold text-green-900">上传成功</h2>
+        <p className="mt-2 text-sm text-green-800">
+          作品已上传完成，以下是 ZIP 中 JavaScript 压缩后的字符统计结果。
+        </p>
+      </div>
+
+      <div className="rounded-xl border border-gray-200 bg-white p-6 shadow-sm">
+        <h3 className="text-lg font-semibold text-gray-900">JS 压缩统计</h3>
+        <dl className="mt-4 grid gap-4 text-sm text-gray-700 sm:grid-cols-2">
+          <div className="rounded-lg bg-gray-50 p-4">
+            <dt className="text-gray-500">压缩后 JS 总字符数</dt>
+            <dd className="mt-1 text-2xl font-semibold text-gray-900">
+              {formatNumber(jsAnalysis.totalMinifiedJsChars)}
+            </dd>
+          </div>
+          <div className="rounded-lg bg-gray-50 p-4">
+            <dt className="text-gray-500">字符上限</dt>
+            <dd className="mt-1 text-2xl font-semibold text-gray-900">
+              {formatNumber(jsAnalysis.jsCharLimit)}
+            </dd>
+          </div>
+          <div className="rounded-lg bg-gray-50 p-4">
+            <dt className="text-gray-500">是否超限</dt>
+            <dd
+              className={`mt-1 text-2xl font-semibold ${
+                isOverLimit ? "text-red-600" : "text-green-600"
+              }`}
+            >
+              {isOverLimit ? "是" : "否"}
+            </dd>
+          </div>
+          <div className="rounded-lg bg-gray-50 p-4">
+            <dt className="text-gray-500">超出字符数</dt>
+            <dd className="mt-1 text-2xl font-semibold text-gray-900">
+              {formatNumber(jsAnalysis.excessChars)}
+            </dd>
+          </div>
+          <div className="rounded-lg bg-gray-50 p-4 sm:col-span-2">
+            <dt className="text-gray-500">票数系数</dt>
+            <dd className="mt-1 text-2xl font-semibold text-gray-900">
+              {jsAnalysis.scoreMultiplier.toFixed(4)}
+            </dd>
+          </div>
+        </dl>
+
+        <div className="mt-6">
+          <h4 className="text-sm font-semibold text-gray-900">JS 文件明细</h4>
+          {jsAnalysis.jsFiles.length > 0 ? (
+            <ul className="mt-3 divide-y divide-gray-100 rounded-lg border border-gray-100">
+              {jsAnalysis.jsFiles.map((file) => (
+                <li
+                  key={file.path}
+                  className="flex items-center justify-between gap-4 px-4 py-3 text-sm"
+                >
+                  <span className="break-all text-gray-700">{file.path}</span>
+                  <span className="shrink-0 font-medium text-gray-900">
+                    {formatNumber(file.minifiedChars)} 字符
+                  </span>
+                </li>
+              ))}
+            </ul>
+          ) : (
+            <p className="mt-3 text-sm text-gray-500">
+              未发现需要统计的本地 JS 文件。
+            </p>
+          )}
+        </div>
+      </div>
+
+      <div className="flex flex-wrap gap-4">
+        <Link
+          href={`/games/${game._id}`}
+          className="px-6 py-2 bg-blue-600 text-white font-medium rounded-lg hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
+        >
+          进入作品详情
+        </Link>
+        <button
+          type="button"
+          onClick={onUploadAnother}
+          className="px-6 py-2 bg-gray-200 text-gray-800 font-medium rounded-lg hover:bg-gray-300 focus:outline-none focus:ring-2 focus:ring-gray-500 focus:ring-offset-2"
+        >
+          继续上传其他作品
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function formatNumber(value: number): string {
+  return value.toLocaleString("zh-CN");
 }
 
 function getErrorMessage(error: UploadGameActionError | null): string | null {

--- a/lib/validation/game-zip.ts
+++ b/lib/validation/game-zip.ts
@@ -1,12 +1,15 @@
 import JSZip, { type JSZipObject } from "jszip";
 import { parse } from "parse5";
 import type { DefaultTreeAdapterMap } from "parse5";
+import { minify } from "terser";
 
 type Element = DefaultTreeAdapterMap["element"];
 
 const HTML_FILE_PATTERN = /\.html?$/i;
+const JS_FILE_PATTERN = /\.(?:js|mjs)$/i;
 const JAVASCRIPT_PROTOCOL_ATTRS = new Set(["href", "src", "action", "formaction"]);
 const ALLOWED_SCRIPT_TYPES = new Set(["application/json", "application/ld+json"]);
+const JS_CHAR_LIMIT = 10000;
 
 export const DEFAULT_GAME_ZIP_LIMITS = {
   maxProcessingMs: 30000,
@@ -28,6 +31,19 @@ export interface GameZipViolation {
   message?: string;
 }
 
+export interface GameZipJsFile {
+  path: string;
+  minifiedChars: number;
+}
+
+export interface GameZipJsAnalysis {
+  totalMinifiedJsChars: number;
+  jsCharLimit: number;
+  excessChars: number;
+  scoreMultiplier: number;
+  jsFiles: GameZipJsFile[];
+}
+
 export interface HtmlZipAnalysisErrorResult {
   passed: false;
   violations: GameZipViolation[];
@@ -42,6 +58,7 @@ export interface GameZipEntry {
 export interface HtmlZipAnalysisPassedResult {
   passed: true;
   violations: GameZipViolation[];
+  jsAnalysis: GameZipJsAnalysis;
 }
 
 export interface HtmlZipAnalysisViolationResult {
@@ -74,7 +91,8 @@ export type GameZipAnalysisErrorCode =
   | "resource_limit_exceeded"
   | "analysis_timeout"
   | "missing_index_html"
-  | "invalid_html_file";
+  | "invalid_html_file"
+  | "js_minify_failed";
 
 export interface GameZipAnalysisError {
   code: GameZipAnalysisErrorCode;
@@ -104,6 +122,16 @@ type PathNormalizationResult =
   | (HtmlZipAnalysisErrorResult & {
       ok: false;
     });
+
+type GameZipJsAnalysisResult =
+  | {
+      ok: true;
+      data: GameZipJsAnalysis;
+    }
+  | {
+      ok: false;
+      error: GameZipAnalysisError;
+    };
 
 export function isStructuredUploadGameError(
   error: UploadGameActionError,
@@ -162,6 +190,7 @@ export async function analyzeGameZip(
     return {
       passed: true,
       violations: inspection.violations,
+      jsAnalysis: inspection.jsAnalysis,
     };
   }
 
@@ -285,10 +314,97 @@ export async function inspectGameZip(
     };
   }
 
+  const jsAnalysisResult = await analyzeMinifiedJs(entries, deadline);
+  if (!jsAnalysisResult.ok) {
+    return createAnalysisError(
+      jsAnalysisResult.error.code,
+      jsAnalysisResult.error.message,
+      jsAnalysisResult.error.file,
+    );
+  }
+
   return {
     passed: true,
     violations,
     entries,
+    jsAnalysis: jsAnalysisResult.data,
+  };
+}
+
+async function analyzeMinifiedJs(
+  entries: GameZipEntry[],
+  deadline: number,
+): Promise<GameZipJsAnalysisResult> {
+  const jsFiles: GameZipJsFile[] = [];
+
+  for (const entry of entries) {
+    if (!JS_FILE_PATTERN.test(entry.path)) {
+      continue;
+    }
+
+    const timeoutError = getTimeoutError(deadline);
+    if (timeoutError) {
+      return {
+        ok: false,
+        error: timeoutError,
+      };
+    }
+
+    try {
+      const minified = await minify(
+        { [entry.path]: entry.data.toString("utf8") },
+        {
+          compress: true,
+          mangle: true,
+        },
+      );
+
+      jsFiles.push({
+        path: entry.path,
+        minifiedChars: (minified.code ?? "").length,
+      });
+    } catch (error) {
+      return {
+        ok: false,
+        error: {
+          code: "js_minify_failed",
+          message:
+            error instanceof Error
+              ? `压缩 JS 文件 "${entry.path}" 时失败：${error.message}`
+              : `压缩 JS 文件 "${entry.path}" 时失败`,
+          file: entry.path,
+        },
+      };
+    }
+
+    const postMinifyTimeoutError = getTimeoutError(deadline);
+    if (postMinifyTimeoutError) {
+      return {
+        ok: false,
+        error: postMinifyTimeoutError,
+      };
+    }
+  }
+
+  return {
+    ok: true,
+    data: createJsAnalysis(jsFiles),
+  };
+}
+
+function createJsAnalysis(jsFiles: GameZipJsFile[]): GameZipJsAnalysis {
+  const totalMinifiedJsChars = jsFiles.reduce(
+    (total, file) => total + file.minifiedChars,
+    0,
+  );
+  const excessChars = Math.max(0, totalMinifiedJsChars - JS_CHAR_LIMIT);
+
+  return {
+    totalMinifiedJsChars,
+    jsCharLimit: JS_CHAR_LIMIT,
+    excessChars,
+    scoreMultiplier: Math.exp(-0.8 * (excessChars / JS_CHAR_LIMIT)),
+    jsFiles,
   };
 }
 

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "server-only": "^0.0.1",
     "sonner": "^2.0.7",
     "tailwind-merge": "^3.4.0",
+    "terser": "5.46.1",
     "tiptap-markdown": "^0.9.0",
     "valibot": "^1.1.0"
   },

--- a/types/game-upload.ts
+++ b/types/game-upload.ts
@@ -1,0 +1,7 @@
+import type { SGame } from "@/schema/game";
+import type { GameZipJsAnalysis } from "@/lib/validation/game-zip";
+
+export interface UploadGameActionSuccessData {
+  game: SGame;
+  jsAnalysis: GameZipJsAnalysis;
+}


### PR DESCRIPTION
feat: 增加上传 ZIP 后的 JS 压缩字符统计

## 概要

在现有 ZIP 上传分析流程中，新增本地 JS 文件的压缩字符统计。

- 使用 `terser@5.46.1` 按 `compress + mangle` 压缩 ZIP 内所有 `.js` / `.mjs` 文件
- 统计压缩后的总字符数，并计算是否超限、超出字符数和票数系数
- 任一 JS 文件压缩失败时，返回 `js_minify_failed` 并带出问题文件路径
- 上传成功后，在上传页展示总字符数、票数系数和逐文件明细

## 规则

- JS 字符数上限：`10000`
- 超出字符数：`max(0, totalMinifiedJsChars - 10000)`
- 票数系数：`Math.exp(-0.8 * (x / 10000))`

## 验证

- `npx tsc --noEmit`
- `npm run lint`