### PR TITLE
feat: 新增作品 ZIP 中美术资产和其他附件的大小统计

### DIFF
--- a/app/actions/game.ts
+++ b/app/actions/game.ts
@@ -99,7 +99,7 @@ export async function uploadGameAction(
     };
   }
 
-  const { entries, jsAnalysis } = inspectionResult;
+  const { entries, jsAnalysis, assetAnalysis } = inspectionResult;
 
   // Save game metadata to database first
   const newGame = await createGame({
@@ -133,6 +133,7 @@ export async function uploadGameAction(
     data: {
       game: newGame,
       jsAnalysis,
+      assetAnalysis,
     },
   };
 }

--- a/components/games/GameUploadForm.tsx
+++ b/components/games/GameUploadForm.tsx
@@ -6,14 +6,14 @@ import { type Result } from "@/types/common/result";
 import { type UploadGameActionSuccessData } from "@/types/game-upload";
 import {
   ASSET_LIMIT_BYTES,
+  MAX_MODEL_WEIGHT_TOTAL_BYTES,
+  formatMegabytes,
+} from "@/lib/validation/game-zip-limits";
+import {
   isStructuredUploadGameError,
   type HtmlZipValidationError,
   type UploadGameActionError,
 } from "@/lib/validation/game-zip";
-import {
-  MAX_MODEL_WEIGHT_TOTAL_BYTES,
-  formatMegabytes,
-} from "@/lib/validation/model-weight";
 
 interface GameUploadFormProps {
   action: (
@@ -27,9 +27,8 @@ export function GameUploadForm({ action }: GameUploadFormProps) {
   const [zipFile, setZipFile] = useState<File | null>(null);
   const [error, setError] = useState<UploadGameActionError | null>(null);
   const [isSaving, setIsSaving] = useState(false);
-  const [successData, setSuccessData] = useState<UploadGameActionSuccessData | null>(
-    null,
-  );
+  const [successData, setSuccessData] =
+    useState<UploadGameActionSuccessData | null>(null);
 
   const handleFileChange = (file: File | null) => {
     setZipFile(file);
@@ -182,14 +181,15 @@ export function GameUploadForm({ action }: GameUploadFormProps) {
         />
         {zipFile && (
           <p className="mt-2 text-sm text-gray-600">
-            Selected: {zipFile.name} ({(zipFile.size / (1024 * 1024)).toFixed(2)} MB)
+            Selected: {zipFile.name} (
+            {(zipFile.size / (1024 * 1024)).toFixed(2)} MB)
           </p>
         )}
         <p className="mt-1 text-xs text-gray-500">
-          The ZIP must contain an index.html at the root level. HTML files cannot contain inline JavaScript.
-          AI model weight files (.pth/.safetensors/.pt/.ckpt/.onnx/.gguf 等) combined size must be ≤{" "}
-          {formatMegabytes(MAX_MODEL_WEIGHT_TOTAL_BYTES)}. 美术资产和其他附件总大小不得超过{" "}
-          {formatMegabytes(ASSET_LIMIT_BYTES)}.
+          压缩包的根目录必须含有index.html. HTML
+          文件不能有内嵌的javascript（需要写成独立的js文件）.
+          AI模型的权重不能超过 {formatMegabytes(MAX_MODEL_WEIGHT_TOTAL_BYTES)}.
+          美术资产和其他附件总大小不得超过 {formatMegabytes(ASSET_LIMIT_BYTES)}.
         </p>
       </div>
 
@@ -229,7 +229,8 @@ function UploadSummary({ data, onUploadAnother }: UploadSummaryProps) {
       <div className="rounded-xl border border-green-200 bg-green-50 p-6">
         <h2 className="text-xl font-semibold text-green-900">上传成功</h2>
         <p className="mt-2 text-sm text-green-800">
-          作品已上传完成，以下是 ZIP 中 JavaScript 压缩后的字符统计结果和资产大小统计结果。
+          作品已上传完成，以下是 ZIP 中 JavaScript
+          压缩后的字符统计结果和资产大小统计结果。
         </p>
       </div>
 
@@ -402,9 +403,7 @@ function getWeightDetails(
   return error.modelWeightDetails ?? null;
 }
 
-function getAssetDetails(
-  error: UploadGameActionError | null,
-): {
+function getAssetDetails(error: UploadGameActionError | null): {
   totalAssetBytes: number;
   assetLimitBytes: number;
   assetFiles: { file: string; sizeBytes: number }[];

--- a/components/games/GameUploadForm.tsx
+++ b/components/games/GameUploadForm.tsx
@@ -5,6 +5,7 @@ import { useState } from "react";
 import { type Result } from "@/types/common/result";
 import { type UploadGameActionSuccessData } from "@/types/game-upload";
 import {
+  ASSET_LIMIT_BYTES,
   isStructuredUploadGameError,
   type HtmlZipValidationError,
   type UploadGameActionError,
@@ -63,6 +64,7 @@ export function GameUploadForm({ action }: GameUploadFormProps) {
   const validationError = getHtmlValidationError(error);
   const errorMessage = getErrorMessage(error);
   const weightDetails = getWeightDetails(error);
+  const assetDetails = getAssetDetails(error);
   const submitDisabled = isSaving;
 
   if (successData) {
@@ -103,6 +105,21 @@ export function GameUploadForm({ action }: GameUploadFormProps) {
                 </li>
               ))}
             </ul>
+          )}
+          {assetDetails && assetDetails.assetFiles.length > 0 && (
+            <div className="mt-3 text-sm">
+              <p>
+                资产总大小：{formatMegabytes(assetDetails.totalAssetBytes)} /{" "}
+                {formatMegabytes(assetDetails.assetLimitBytes)}
+              </p>
+              <ul className="mt-2 list-disc pl-5">
+                {assetDetails.assetFiles.slice(0, 5).map((file) => (
+                  <li key={file.file}>
+                    {file.file} — {formatMegabytes(file.sizeBytes)}
+                  </li>
+                ))}
+              </ul>
+            </div>
           )}
         </div>
       )}
@@ -171,7 +188,8 @@ export function GameUploadForm({ action }: GameUploadFormProps) {
         <p className="mt-1 text-xs text-gray-500">
           The ZIP must contain an index.html at the root level. HTML files cannot contain inline JavaScript.
           AI model weight files (.pth/.safetensors/.pt/.ckpt/.onnx/.gguf 等) combined size must be ≤{" "}
-          {formatMegabytes(MAX_MODEL_WEIGHT_TOTAL_BYTES)}.
+          {formatMegabytes(MAX_MODEL_WEIGHT_TOTAL_BYTES)}. 美术资产和其他附件总大小不得超过{" "}
+          {formatMegabytes(ASSET_LIMIT_BYTES)}.
         </p>
       </div>
 
@@ -201,16 +219,69 @@ interface UploadSummaryProps {
 }
 
 function UploadSummary({ data, onUploadAnother }: UploadSummaryProps) {
-  const { game, jsAnalysis } = data;
-  const isOverLimit = jsAnalysis.excessChars > 0;
+  const { game, jsAnalysis, assetAnalysis } = data;
+  const isJsOverLimit = jsAnalysis.excessChars > 0;
+  const isAssetOverLimit = !assetAnalysis.passed;
+  const largestAssetFiles = assetAnalysis.assetFiles.slice(0, 5);
 
   return (
     <div className="space-y-6">
       <div className="rounded-xl border border-green-200 bg-green-50 p-6">
         <h2 className="text-xl font-semibold text-green-900">上传成功</h2>
         <p className="mt-2 text-sm text-green-800">
-          作品已上传完成，以下是 ZIP 中 JavaScript 压缩后的字符统计结果。
+          作品已上传完成，以下是 ZIP 中 JavaScript 压缩后的字符统计结果和资产大小统计结果。
         </p>
+      </div>
+
+      <div className="rounded-xl border border-gray-200 bg-white p-6 shadow-sm">
+        <h3 className="text-lg font-semibold text-gray-900">资产大小统计</h3>
+        <dl className="mt-4 grid gap-4 text-sm text-gray-700 sm:grid-cols-3">
+          <div className="rounded-lg bg-gray-50 p-4">
+            <dt className="text-gray-500">资产总大小</dt>
+            <dd className="mt-1 text-2xl font-semibold text-gray-900">
+              {formatMegabytes(assetAnalysis.totalAssetBytes)}
+            </dd>
+          </div>
+          <div className="rounded-lg bg-gray-50 p-4">
+            <dt className="text-gray-500">限制值</dt>
+            <dd className="mt-1 text-2xl font-semibold text-gray-900">
+              {formatMegabytes(assetAnalysis.assetLimitBytes)}
+            </dd>
+          </div>
+          <div className="rounded-lg bg-gray-50 p-4">
+            <dt className="text-gray-500">是否超限</dt>
+            <dd
+              className={`mt-1 text-2xl font-semibold ${
+                isAssetOverLimit ? "text-red-600" : "text-green-600"
+              }`}
+            >
+              {isAssetOverLimit ? "是" : "否"}
+            </dd>
+          </div>
+        </dl>
+
+        <div className="mt-6">
+          <h4 className="text-sm font-semibold text-gray-900">最大资产文件</h4>
+          {largestAssetFiles.length > 0 ? (
+            <ul className="mt-3 divide-y divide-gray-100 rounded-lg border border-gray-100">
+              {largestAssetFiles.map((file) => (
+                <li
+                  key={file.file}
+                  className="flex items-center justify-between gap-4 px-4 py-3 text-sm"
+                >
+                  <span className="break-all text-gray-700">{file.file}</span>
+                  <span className="shrink-0 font-medium text-gray-900">
+                    {formatMegabytes(file.sizeBytes)}
+                  </span>
+                </li>
+              ))}
+            </ul>
+          ) : (
+            <p className="mt-3 text-sm text-gray-500">
+              未发现计入资产大小的文件。
+            </p>
+          )}
+        </div>
       </div>
 
       <div className="rounded-xl border border-gray-200 bg-white p-6 shadow-sm">
@@ -232,10 +303,10 @@ function UploadSummary({ data, onUploadAnother }: UploadSummaryProps) {
             <dt className="text-gray-500">是否超限</dt>
             <dd
               className={`mt-1 text-2xl font-semibold ${
-                isOverLimit ? "text-red-600" : "text-green-600"
+                isJsOverLimit ? "text-red-600" : "text-green-600"
               }`}
             >
-              {isOverLimit ? "是" : "否"}
+              {isJsOverLimit ? "是" : "否"}
             </dd>
           </div>
           <div className="rounded-lg bg-gray-50 p-4">
@@ -329,4 +400,18 @@ function getWeightDetails(
   }
   if (error.code !== "model_weight_total_too_large") return null;
   return error.modelWeightDetails ?? null;
+}
+
+function getAssetDetails(
+  error: UploadGameActionError | null,
+): {
+  totalAssetBytes: number;
+  assetLimitBytes: number;
+  assetFiles: { file: string; sizeBytes: number }[];
+} | null {
+  if (!error || typeof error === "string" || !("code" in error)) {
+    return null;
+  }
+  if (error.code !== "asset_total_too_large") return null;
+  return error.assetDetails ?? null;
 }

--- a/lib/validation/game-zip-limits.ts
+++ b/lib/validation/game-zip-limits.ts
@@ -1,6 +1,10 @@
-// Client-safe constants and helpers for AI model weight validation.
+// Client-safe constants and helpers for game ZIP validation.
 // Kept separate from lib/validation/game-zip.ts so the browser bundle does
-// not pull in parse5 / the Node-only ZIP inspection pipeline.
+// not pull in jszip / parse5 / terser.
+
+export const ASSET_LIMIT_BYTES = 10 * 1024 * 1024;
+
+export const MAX_MODEL_WEIGHT_TOTAL_BYTES = 200 * 1024 * 1024;
 
 export const MODEL_WEIGHT_EXTENSIONS: readonly string[] = [
   ".pth",
@@ -19,8 +23,6 @@ export const MODEL_WEIGHT_EXTENSIONS: readonly string[] = [
   ".npz",
   ".pkl",
 ];
-
-export const MAX_MODEL_WEIGHT_TOTAL_BYTES = 200 * 1024 * 1024;
 
 export function isModelWeightFile(path: string): boolean {
   const lower = path.toLowerCase();

--- a/lib/validation/game-zip.test.ts
+++ b/lib/validation/game-zip.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, test } from "bun:test";
 import JSZip from "jszip";
 import {
+  ASSET_LIMIT_BYTES,
+  analyzeAssetSize,
   checkModelWeightTotalSize,
   createModelWeightTotalTooLargeError,
   hasGameZipAnalysisError,
@@ -23,6 +25,72 @@ function fakeWeightBuffer(bytes: number): Buffer {
   for (let i = 0; i < bytes; i++) buf[i] = Math.floor(Math.random() * 256);
   return buf;
 }
+
+describe("analyzeAssetSize", () => {
+  test("returns 0 when there are no files", () => {
+    const result = analyzeAssetSize([]);
+
+    expect(result.passed).toBe(true);
+    expect(result.totalAssetBytes).toBe(0);
+    expect(result.assetLimitBytes).toBe(ASSET_LIMIT_BYTES);
+    expect(result.excessAssetBytes).toBe(0);
+    expect(result.assetFiles).toEqual([]);
+  });
+
+  test("ignores html, css, js, and mjs files", () => {
+    const result = analyzeAssetSize([
+      { path: "index.html", data: Buffer.alloc(1024) },
+      { path: "styles/main.css", data: Buffer.alloc(2048) },
+      { path: "scripts/main.js", data: Buffer.alloc(4096) },
+      { path: "scripts/module.mjs", data: Buffer.alloc(8192) },
+    ]);
+
+    expect(result.passed).toBe(true);
+    expect(result.totalAssetBytes).toBe(0);
+    expect(result.assetFiles).toEqual([]);
+  });
+
+  test("counts art assets, audio, and json content by uncompressed bytes", () => {
+    const result = analyzeAssetSize([
+      { path: "assets/logo.png", data: Buffer.alloc(1024) },
+      { path: "audio/theme.mp3", data: Buffer.alloc(2048) },
+      { path: "levels/story.json", data: Buffer.alloc(512) },
+    ]);
+
+    expect(result.passed).toBe(true);
+    expect(result.totalAssetBytes).toBe(3584);
+    expect(result.assetFiles).toEqual([
+      { file: "audio/theme.mp3", sizeBytes: 2048 },
+      { file: "assets/logo.png", sizeBytes: 1024 },
+      { file: "levels/story.json", sizeBytes: 512 },
+    ]);
+  });
+
+  test("excludes existing AI model weight files from asset size", () => {
+    const result = analyzeAssetSize([
+      { path: "weights/model.onnx", data: Buffer.alloc(1024 * 1024) },
+      { path: "assets/logo.png", data: Buffer.alloc(2048) },
+    ]);
+
+    expect(result.passed).toBe(true);
+    expect(result.totalAssetBytes).toBe(2048);
+    expect(result.assetFiles).toEqual([
+      { file: "assets/logo.png", sizeBytes: 2048 },
+    ]);
+  });
+
+  test("fails when multiple asset files exceed the asset limit", () => {
+    const result = analyzeAssetSize([
+      { path: "assets/a.png", data: Buffer.alloc(6 * 1024 * 1024) },
+      { path: "assets/b.wav", data: Buffer.alloc(5 * 1024 * 1024) },
+    ]);
+
+    expect(result.passed).toBe(false);
+    expect(result.totalAssetBytes).toBe(11 * 1024 * 1024);
+    expect(result.assetLimitBytes).toBe(ASSET_LIMIT_BYTES);
+    expect(result.excessAssetBytes).toBe(1024 * 1024);
+  });
+});
 
 describe("checkModelWeightTotalSize", () => {
   test("returns null when no weight files are present", () => {
@@ -158,17 +226,21 @@ describe("inspectGameZip with model weight files", () => {
     expect(result.error.modelWeightDetails!.files).toHaveLength(2);
   });
 
-  test("treats non-weight extensions as out of scope even if they are large", async () => {
-    // A 210 MB asset that is not a weight file should not trip the check.
+  test("rejects non-weight asset files over the asset limit", async () => {
     const zipBytes = await buildZip({
       "index.html": "<!doctype html><html><body></body></html>",
-      "assets/huge-texture.png": fakeWeightBuffer(
-        MAX_MODEL_WEIGHT_TOTAL_BYTES + 8 * 1024 * 1024,
-      ),
+      "assets/huge-texture.png": Buffer.alloc(ASSET_LIMIT_BYTES + 1),
     });
 
     const result = await inspectGameZip(zipBytes, { requireRootIndexHtml: true });
-    expect(hasGameZipAnalysisError(result)).toBe(false);
-    expect(result.passed).toBe(true);
+    expect(hasGameZipAnalysisError(result)).toBe(true);
+    if (!hasGameZipAnalysisError(result)) return;
+
+    expect(result.error.code).toBe("asset_total_too_large");
+    expect(result.error.message).toContain("美术资产和其他附件总大小");
+    expect(result.error.assetDetails?.totalAssetBytes).toBe(
+      ASSET_LIMIT_BYTES + 1,
+    );
+    expect(result.error.assetDetails?.assetLimitBytes).toBe(ASSET_LIMIT_BYTES);
   });
 });

--- a/lib/validation/game-zip.ts
+++ b/lib/validation/game-zip.ts
@@ -18,6 +18,7 @@ type Element = DefaultTreeAdapterMap["element"];
 
 const HTML_FILE_PATTERN = /\.html?$/i;
 const JS_FILE_PATTERN = /\.(?:js|mjs)$/i;
+const CSS_FILE_PATTERN = /\.css$/i;
 const JAVASCRIPT_PROTOCOL_ATTRS = new Set([
   "href",
   "src",
@@ -29,6 +30,8 @@ const ALLOWED_SCRIPT_TYPES = new Set([
   "application/ld+json",
 ]);
 const JS_CHAR_LIMIT = 10000;
+
+export const ASSET_LIMIT_BYTES = 10 * 1024 * 1024;
 
 export const DEFAULT_GAME_ZIP_LIMITS = {
   maxProcessingMs: 30000,
@@ -63,6 +66,19 @@ export interface GameZipJsAnalysis {
   jsFiles: GameZipJsFile[];
 }
 
+export interface GameZipAssetFile {
+  file: string;
+  sizeBytes: number;
+}
+
+export interface GameZipAssetAnalysis {
+  totalAssetBytes: number;
+  assetLimitBytes: number;
+  excessAssetBytes: number;
+  passed: boolean;
+  assetFiles: GameZipAssetFile[];
+}
+
 export interface HtmlZipAnalysisErrorResult {
   passed: false;
   violations: GameZipViolation[];
@@ -78,6 +94,7 @@ export interface HtmlZipAnalysisPassedResult {
   passed: true;
   violations: GameZipViolation[];
   jsAnalysis: GameZipJsAnalysis;
+  assetAnalysis: GameZipAssetAnalysis;
 }
 
 export interface HtmlZipAnalysisViolationResult {
@@ -112,6 +129,7 @@ export type GameZipAnalysisErrorCode =
   | "missing_index_html"
   | "invalid_html_file"
   | "model_weight_total_too_large"
+  | "asset_total_too_large"
   | "js_minify_failed";
 
 export interface ModelWeightOversizeDetails {
@@ -125,6 +143,7 @@ export interface GameZipAnalysisError {
   message: string;
   file?: string;
   modelWeightDetails?: ModelWeightOversizeDetails;
+  assetDetails?: GameZipAssetAnalysis;
 }
 
 export type HtmlZipValidationError = HtmlZipAnalysisViolationResult & {
@@ -176,7 +195,7 @@ function createAnalysisError(
   code: GameZipAnalysisErrorCode,
   message: string,
   file?: string,
-  extra?: Pick<GameZipAnalysisError, "modelWeightDetails">,
+  extra?: Pick<GameZipAnalysisError, "modelWeightDetails" | "assetDetails">,
 ): HtmlZipAnalysisErrorResult {
   return {
     passed: false,
@@ -187,6 +206,32 @@ function createAnalysisError(
       file,
       ...extra,
     },
+  };
+}
+
+export function analyzeAssetSize(
+  entries: { path: string; data: Buffer | Uint8Array }[],
+  limitBytes: number = ASSET_LIMIT_BYTES,
+): GameZipAssetAnalysis {
+  const assetFiles = entries
+    .filter((entry) => !isCodeFile(entry.path) && !isModelWeightFile(entry.path))
+    .map((entry) => ({
+      file: entry.path,
+      sizeBytes: entry.data.byteLength,
+    }))
+    .sort((a, b) => b.sizeBytes - a.sizeBytes || a.file.localeCompare(b.file));
+  const totalAssetBytes = assetFiles.reduce(
+    (total, file) => total + file.sizeBytes,
+    0,
+  );
+  const excessAssetBytes = Math.max(0, totalAssetBytes - limitBytes);
+
+  return {
+    totalAssetBytes,
+    assetLimitBytes: limitBytes,
+    excessAssetBytes,
+    passed: excessAssetBytes === 0,
+    assetFiles,
   };
 }
 
@@ -202,6 +247,15 @@ export function createModelWeightTotalTooLargeError(
       modelWeightDetails: details,
     },
   );
+}
+
+export function createAssetTotalTooLargeError(
+  details: GameZipAssetAnalysis,
+): HtmlZipAnalysisErrorResult {
+  const message = `美术资产和其他附件总大小为 ${formatMegabytes(details.totalAssetBytes)}，超过 ${formatMegabytes(details.assetLimitBytes)} 限制`;
+  return createAnalysisError("asset_total_too_large", message, undefined, {
+    assetDetails: details,
+  });
 }
 
 export function createHtmlZipValidationError(
@@ -234,6 +288,7 @@ export async function analyzeGameZip(
       passed: true,
       violations: inspection.violations,
       jsAnalysis: inspection.jsAnalysis,
+      assetAnalysis: inspection.assetAnalysis,
     };
   }
 
@@ -330,6 +385,11 @@ export async function inspectGameZip(
     return createModelWeightTotalTooLargeError(weightCheck);
   }
 
+  const assetAnalysis = analyzeAssetSize(entries);
+  if (!assetAnalysis.passed) {
+    return createAssetTotalTooLargeError(assetAnalysis);
+  }
+
   const violations: GameZipViolation[] = [];
 
   for (const entry of entries) {
@@ -381,7 +441,16 @@ export async function inspectGameZip(
     violations,
     entries,
     jsAnalysis: jsAnalysisResult.data,
+    assetAnalysis,
   };
+}
+
+function isCodeFile(path: string): boolean {
+  return (
+    HTML_FILE_PATTERN.test(path) ||
+    CSS_FILE_PATTERN.test(path) ||
+    JS_FILE_PATTERN.test(path)
+  );
 }
 
 async function analyzeMinifiedJs(

--- a/lib/validation/game-zip.ts
+++ b/lib/validation/game-zip.ts
@@ -2,17 +2,14 @@ import JSZip, { type JSZipObject } from "jszip";
 import { parse } from "parse5";
 import type { DefaultTreeAdapterMap } from "parse5";
 import {
+  ASSET_LIMIT_BYTES,
   MAX_MODEL_WEIGHT_TOTAL_BYTES,
   formatMegabytes,
   isModelWeightFile,
-} from "@/lib/validation/model-weight";
-
-export {
-  MAX_MODEL_WEIGHT_TOTAL_BYTES,
-  MODEL_WEIGHT_EXTENSIONS,
-  isModelWeightFile,
-} from "@/lib/validation/model-weight";
+} from "@/lib/validation/game-zip-limits";
 import { minify } from "terser";
+
+export * from "@/lib/validation/game-zip-limits";
 
 type Element = DefaultTreeAdapterMap["element"];
 
@@ -30,8 +27,6 @@ const ALLOWED_SCRIPT_TYPES = new Set([
   "application/ld+json",
 ]);
 const JS_CHAR_LIMIT = 10000;
-
-export const ASSET_LIMIT_BYTES = 10 * 1024 * 1024;
 
 export const DEFAULT_GAME_ZIP_LIMITS = {
   maxProcessingMs: 30000,
@@ -214,7 +209,9 @@ export function analyzeAssetSize(
   limitBytes: number = ASSET_LIMIT_BYTES,
 ): GameZipAssetAnalysis {
   const assetFiles = entries
-    .filter((entry) => !isCodeFile(entry.path) && !isModelWeightFile(entry.path))
+    .filter(
+      (entry) => !isCodeFile(entry.path) && !isModelWeightFile(entry.path),
+    )
     .map((entry) => ({
       file: entry.path,
       sizeBytes: entry.data.byteLength,

--- a/lib/validation/model-weight.test.ts
+++ b/lib/validation/model-weight.test.ts
@@ -4,7 +4,7 @@ import {
   MODEL_WEIGHT_EXTENSIONS,
   formatMegabytes,
   isModelWeightFile,
-} from "./model-weight";
+} from "./game-zip-limits";
 
 describe("isModelWeightFile", () => {
   test("matches every declared extension case-insensitively", () => {

--- a/types/game-upload.ts
+++ b/types/game-upload.ts
@@ -1,7 +1,11 @@
 import type { SGame } from "@/schema/game";
-import type { GameZipJsAnalysis } from "@/lib/validation/game-zip";
+import type {
+  GameZipAssetAnalysis,
+  GameZipJsAnalysis,
+} from "@/lib/validation/game-zip";
 
 export interface UploadGameActionSuccessData {
   game: SGame;
   jsAnalysis: GameZipJsAnalysis;
+  assetAnalysis: GameZipAssetAnalysis;
 }


### PR DESCRIPTION
## 概要

新增作品 ZIP 中美术资产和其他附件的大小统计，限制为 10MB。

统计口径：

- 不计入 `html/css/js/mjs` 代码文件
- 不计入 AI 模型权重文件
- 其余文件均按解压后字节数计入资产大小

实现复用现有 `inspectGameZip()` 的 entries，以及已有 AI 权重识别逻辑。

## 变更

- 新增 `assetAnalysis`
  - `totalAssetBytes`
  - `assetLimitBytes`
  - `excessAssetBytes`
  - `passed`
  - `assetFiles`
- 资产超过 10MB 时返回 `asset_total_too_large`
- 上传成功页展示资产大小统计
- 资产超限错误展示总大小和前 5 个最大资产文件

## 验证

- `npm exec -- bun test lib/validation/game-zip.test.ts lib/validation/model-weight.test.ts`
- `npm run lint -- app/actions/game.ts components/games/GameUploadForm.tsx lib/validation/game-zip.ts types/game-upload.ts`

Closes #46 